### PR TITLE
Integrar subida y procesamiento de archivos en la barra lateral

### DIFF
--- a/src/components/__init__.py
+++ b/src/components/__init__.py
@@ -1,1 +1,2 @@
 
+from .file_processor import display_file_uploader

--- a/src/components/file_processor.py
+++ b/src/components/file_processor.py
@@ -1,0 +1,55 @@
+"""Componente para la subida y procesamiento de archivos."""
+
+import streamlit as st
+from typing import Any, Dict
+
+from src.api.file_processor import FileProcessor
+
+
+def display_file_uploader(session_state, logger=None) -> None:
+    """Muestra un cargador de archivos y procesa su contenido.
+
+    Este componente permite subir archivos en formato PDF, TXT o JSON,
+    procesarlos con :class:`FileProcessor` y añadir la información
+    obtenida al contexto general de la conversación.
+
+    Args:
+        session_state: Estado de la sesión de Streamlit.
+        logger (logging.Logger, optional): Logger para registrar eventos.
+    """
+    st.subheader("Procesamiento de Archivos")
+    uploaded_file = st.file_uploader(
+        "Selecciona un archivo", type=["pdf", "txt", "json"]
+    )
+
+    if uploaded_file is None:
+        return
+
+    file_bytes = uploaded_file.getvalue()
+    extension = uploaded_file.name.split(".")[-1].lower()
+    processor = FileProcessor(logger=logger)
+    result = processor.process_file(file_bytes, extension)
+
+    if result.get("success"):
+        st.success(f"Archivo '{uploaded_file.name}' procesado correctamente.")
+        file_info: Dict[str, Any] = {
+            "file_name": uploaded_file.name,
+            "file_type": extension,
+            "content": result["content"],
+        }
+        session_state.processed_files = session_state.get("processed_files", [])
+        session_state.processed_files.append(file_info)
+
+        if "messages" not in session_state:
+            session_state.messages = []
+        session_state.messages.append(
+            {
+                "role": "system",
+                "content": (
+                    f"El usuario ha subido el archivo {uploaded_file.name} "
+                    f"de tipo {extension}.\nContenido procesado:\n{result['content']}"
+                ),
+            }
+        )
+    else:
+        st.error(f"Error al procesar el archivo: {result.get('error', 'desconocido')}")

--- a/src/components/sidebar.py
+++ b/src/components/sidebar.py
@@ -7,6 +7,7 @@ import uuid
 from src.models.config import AVAILABLE_MODELS, get_model
 from src.utils.agentic_tools_manager import AgenticToolsManager
 from src.utils.image_processor import resize_image, encode_image_to_base64, save_uploaded_image
+from src.components.file_processor import display_file_uploader
 
 def render_sidebar(session_state, groq_client, logger):
     """
@@ -236,6 +237,8 @@ def render_sidebar(session_state, groq_client, logger):
             value=session_state.context["system_prompt"],
             height=150
         )
+
+        display_file_uploader(session_state, logger)
         
         # Detectar cambios en la configuración
         config_changed = False


### PR DESCRIPTION
## Summary
- add `display_file_uploader` component for PDF, TXT and JSON
- expose the new component in `src/components/__init__`
- invoke file uploader in sidebar to process files and store their content in `session_state`

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_683f477d96cc832b811fcfe20672e971